### PR TITLE
better error message for failed authentication attempt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,32 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    actionpack (2.3.8)
-      activesupport (= 2.3.8)
+    actionpack (2.3.14)
+      activesupport (= 2.3.14)
       rack (~> 1.1.0)
-    activesupport (2.3.8)
-    addressable (2.2.0)
-    crack (0.1.8)
-    curb (0.7.7.1)
+    activesupport (2.3.14)
+    addressable (2.2.6)
+    crack (0.3.1)
+    curb (0.7.16)
     em-http-request (0.2.11)
       addressable (>= 2.0.0)
       eventmachine (>= 0.12.9)
     eventmachine (0.12.10)
-    gemcutter (0.4.1)
-      json_pure
     git (1.2.5)
-    jeweler (1.4.0)
-      gemcutter (>= 0.1.0)
+    jeweler (1.6.4)
+      bundler (~> 1.0)
       git (>= 1.2.5)
-      rubyforge (>= 2.0.0)
-    json_pure (1.4.3)
-    mocha (0.9.8)
       rake
-    rack (1.1.0)
-    rake (0.8.7)
-    rubyforge (2.0.4)
-      json_pure (>= 1.1.7)
-    typhoeus (0.1.31)
-      rack
-    webmock (1.3.5)
-      addressable (>= 2.1.1)
+    metaclass (0.0.1)
+    mime-types (1.17.2)
+    mocha (0.10.0)
+      metaclass (~> 0.0.1)
+    rack (1.1.2)
+    rake (0.9.2.2)
+    typhoeus (0.3.3)
+      mime-types
+    webmock (1.7.8)
+      addressable (~> 2.2, > 2.2.5)
       crack (>= 0.1.7)
 
 PLATFORMS

--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -159,6 +159,7 @@ module OAuth
       req = create_signed_request(http_method, path, token, request_options, *arguments)
       return nil if block_given? and yield(req) == :done
       rsp = http.request(req)
+
       # check for an error reported by the Problem Reporting extension
       # (http://wiki.oauth.net/ProblemReporting)
       # note: a 200 may actually be an error; check for an oauth_problem key to be sure
@@ -213,6 +214,12 @@ module OAuth
         response.error! if uri.path == path # careful of those infinite redirects
         self.token_request(http_method, uri.path, token, request_options, arguments)
       when (400..499)
+        def response.message
+          s = response.body
+          s << "Response Headers: "
+          response.each_header{|k,v| s << "\n#{k}: #{v}"}
+          s
+        end
         raise OAuth::Unauthorized, response
       else
         response.error!


### PR DESCRIPTION
This code is not really intended for production use, but I thought I'd show you what I had to do in order to get a sensible error message and properly debug my code. 

A real patch would probably change the base OAuth::Problem class, have it take a request *or* a response or both (right now it only takes a request), and read some data out of it and put it in the exception message string (which, let's face it, is all people ever see when something goes wrong).

Let me know if you want me to do that work. I'm pretty busy but I'll try to squeeze it in. In the meantime, this hack is better than what's there now, so you may want to just accept it and then add an issue to improve it.