### PR TITLE
Removed spaces when sending parameters in header for some implementations

### DIFF
--- a/lib/oauth/client/helper.rb
+++ b/lib/oauth/client/helper.rb
@@ -74,9 +74,9 @@ module OAuth::Client
       parameters = oauth_parameters
       parameters.merge!('oauth_signature' => signature(options.merge(:parameters => parameters)))
 
-      header_params_str = parameters.sort.map { |k,v| "#{k}=\"#{escape(v)}\"" }.join(', ')
+      header_params_str = parameters.sort.map { |k,v| "#{k}=\"#{escape(v)}\"" }.join(',')
 
-      realm = "realm=\"#{options[:realm]}\", " if options[:realm]
+      realm = "realm=\"#{options[:realm]}\"," if options[:realm]
       "OAuth #{realm}#{header_params_str}"
     end
 

--- a/lib/oauth/request_proxy/base.rb
+++ b/lib/oauth/request_proxy/base.rb
@@ -136,9 +136,9 @@ module OAuth::RequestProxy
 
     # Authorization header for OAuth
     def oauth_header(options = {})
-      header_params_str = oauth_parameters.map { |k,v| "#{k}=\"#{escape(v)}\"" }.join(', ')
+      header_params_str = oauth_parameters.map { |k,v| "#{k}=\"#{escape(v)}\"" }.join(',')
 
-      realm = "realm=\"#{options[:realm]}\", " if options[:realm]
+      realm = "realm=\"#{options[:realm]}\"," if options[:realm]
       "OAuth #{realm}#{header_params_str}"
     end
 

--- a/test/integration/consumer_test.rb
+++ b/test/integration/consumer_test.rb
@@ -28,7 +28,7 @@ module Integration
 
       assert_equal 'GET', request.method
       assert_equal '/test?key=value', request.path
-      assert_equal "OAuth oauth_nonce=\"225579211881198842005988698334675835446\", oauth_signature_method=\"HMAC-SHA1\", oauth_token=\"token_411a7f\", oauth_timestamp=\"1199645624\", oauth_consumer_key=\"consumer_key_86cad9\", oauth_signature=\"1oO2izFav1GP4kEH2EskwXkCRFg%3D\", oauth_version=\"1.0\"".delete(',').split.sort, request['authorization'].delete(',').split.sort
+      assert_equal "OAuth oauth_consumer_key=\"consumer_key_86cad9\",oauth_signature_method=\"HMAC-SHA1\",oauth_nonce=\"225579211881198842005988698334675835446\",oauth_token=\"token_411a7f\",oauth_timestamp=\"1199645624\",oauth_signature=\"1oO2izFav1GP4kEH2EskwXkCRFg%3D\",oauth_version=\"1.0\"".split(',').sort, request['authorization'].split(',').sort
     end
 
     def test_that_setting_signature_method_on_consumer_effects_signing
@@ -76,7 +76,7 @@ module Integration
       assert_equal 'POST', request.method
       assert_equal '/test', request.path
       assert_equal 'key=value', request.body
-      assert_equal "OAuth oauth_nonce=\"225579211881198842005988698334675835446\", oauth_signature_method=\"HMAC-SHA1\", oauth_token=\"token_411a7f\", oauth_timestamp=\"1199645624\", oauth_consumer_key=\"consumer_key_86cad9\", oauth_signature=\"26g7wHTtNO6ZWJaLltcueppHYiI%3D\", oauth_version=\"1.0\"".delete(',').split.sort, request['authorization'].delete(',').split.sort
+      assert_equal "OAuth oauth_consumer_key=\"consumer_key_86cad9\",oauth_nonce=\"225579211881198842005988698334675835446\",oauth_signature_method=\"HMAC-SHA1\",oauth_token=\"token_411a7f\",oauth_timestamp=\"1199645624\",oauth_signature=\"26g7wHTtNO6ZWJaLltcueppHYiI%3D\",oauth_version=\"1.0\"".split(',').sort, request['authorization'].split(',').sort
     end
 
     def test_that_signing_post_params_works
@@ -95,7 +95,7 @@ module Integration
 
       assert_equal 'GET', request.method
       assert_equal '/test?key=value', request.path
-      assert_equal "OAuth oauth_nonce=\"225579211881198842005988698334675835446\", oauth_signature_method=\"HMAC-SHA1\", oauth_token=\"token_411a7f\", oauth_timestamp=\"1199645624\", oauth_consumer_key=\"consumer_key_86cad9\", oauth_signature=\"1oO2izFav1GP4kEH2EskwXkCRFg%3D\", oauth_version=\"1.0\"".delete(',').split.sort, request['authorization'].delete(',').split.sort
+      assert_equal "OAuth oauth_consumer_key=\"consumer_key_86cad9\",oauth_nonce=\"225579211881198842005988698334675835446\",oauth_signature_method=\"HMAC-SHA1\",oauth_token=\"token_411a7f\",oauth_timestamp=\"1199645624\",oauth_signature=\"1oO2izFav1GP4kEH2EskwXkCRFg%3D\",oauth_version=\"1.0\"".split(',').sort, request['authorization'].split(',').sort
     end
 
     def test_that_using_auth_headers_on_post_on_create_signed_requests_works
@@ -103,7 +103,7 @@ module Integration
       assert_equal 'POST', request.method
       assert_equal '/test', request.path
       assert_equal 'key=value', request.body
-      assert_equal "OAuth oauth_nonce=\"225579211881198842005988698334675835446\", oauth_signature_method=\"HMAC-SHA1\", oauth_token=\"token_411a7f\", oauth_timestamp=\"1199645624\", oauth_consumer_key=\"consumer_key_86cad9\", oauth_signature=\"26g7wHTtNO6ZWJaLltcueppHYiI%3D\", oauth_version=\"1.0\"".delete(',').split.sort, request['authorization'].delete(',').split.sort
+      assert_equal "OAuth oauth_consumer_key=\"consumer_key_86cad9\",oauth_nonce=\"225579211881198842005988698334675835446\",oauth_signature_method=\"HMAC-SHA1\",oauth_token=\"token_411a7f\",oauth_timestamp=\"1199645624\",oauth_signature=\"26g7wHTtNO6ZWJaLltcueppHYiI%3D\",oauth_version=\"1.0\"".split(',').sort, request['authorization'].split(',').sort
     end
 
     def test_that_signing_post_params_works_2

--- a/test/test_net_http_client.rb
+++ b/test/test_net_http_client.rb
@@ -201,7 +201,7 @@ class NetHTTPClientTest < Test::Unit::TestCase
     assert_equal 'GET', request.method
     correct_sorted_params = 'oauth_nonce="kllo9940pd9333jh", oauth_signature_method="HMAC-SHA1", oauth_token="nnch734d00sl2jdk", oauth_timestamp="1191242096", oauth_consumer_key="dpf43f3p2l4k3l03", oauth_signature="tR3%2BTy81lMeYAr%2FFid0kMTYa%2FWM%3D", oauth_version="1.0"'.split(', ').sort
     correct_sorted_params.unshift 'OAuth realm="http://photos.example.net/"'
-    assert_equal correct_sorted_params, request['authorization'].split(', ').sort
+    assert_equal correct_sorted_params, request['authorization'].split(',').sort
   end
 
   def test_step_by_step_token_request


### PR DESCRIPTION
I've noticed that some oauth-server implementations choke on the empty space after a key so that the rest of the parameter-keys in the header don't get evaluated and the server will throw a 400 Bad Request.

Since this is probably a wrong implementation on the server-side, it isn't that big of a problem in this lib. But it can't be wrong to make the client more flexible to work with these situations without breaking things; this commit fixes the problems I was facing. Existing test modifications consist of making them work without the spaces after a comma, which they do now.

I am just going ahead and send in this pull request; decide for yourself if it is going to be pulled in.
My project def. needs this patch; caused me headaches and several hours of digging and poking around in Wireshark ;)