### PR TITLE
Implement method body on RackRequest

### DIFF
--- a/lib/oauth/helper.rb
+++ b/lib/oauth/helper.rb
@@ -78,7 +78,9 @@ module OAuth
     #
     def parse_header(header)
       # decompose
-      params = header[6,header.length].split(/[,=&]/)
+      params = header[6,header.length]
+      raise OAuth::Problem.new("Invalid authorization header") if params.nil?
+      params = params.split(/[,=&]/)
 
       # odd number of arguments - must be a malformed header.
       raise OAuth::Problem.new("Invalid authorization header") if params.size % 2 != 0

--- a/lib/oauth/request_proxy/rack_request.rb
+++ b/lib/oauth/request_proxy/rack_request.rb
@@ -30,6 +30,16 @@ module OAuth::RequestProxy
       end
     end
 
+    def parameters_for_signature
+      param_hash = parameters.reject { |k,v| k == "oauth_signature" || unsigned_parameters.include?(k)}
+      array_values = param_hash.select {|k,v| v.kind_of?(Array)}
+      array_values.each do |k,v|
+        param_hash.delete(k)
+        param_hash["#{k}[]"] = v
+      end
+      param_hash
+    end
+    
     def signature
       parameters['oauth_signature']
     end

--- a/lib/oauth/request_proxy/rack_request.rb
+++ b/lib/oauth/request_proxy/rack_request.rb
@@ -14,6 +14,13 @@ module OAuth::RequestProxy
       request.url
     end
 
+    def body
+      body_string = request.body.read
+      #rewind the StringIO so other mehtods can use it as well
+      request.body.rewind
+      body_string
+    end
+
     def parameters
       if options[:clobber_request]
         options[:parameters] || {}


### PR DESCRIPTION
When using Sinatra with oauth-ruby, the signature module, the request proxy created by OAuth::Signature.build is an instance of RackRequest which has not implemented the method body, so calling signature.body_hash fails with NoMethodError.

I am implementing the missing method which reads the request object of Rack::Request and rewinds it to be used by other methods as well