### PR TITLE
Fix adding paths when a full URL has been specified

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -234,8 +234,8 @@ module OAuth
     end
 
     def request_endpoint
-  return nil if @options[:request_endpoint].nil?
-  @options[:request_endpoint].to_s
+      return nil if @options[:request_endpoint].nil?
+      @options[:request_endpoint].to_s
     end
 
     def scheme

--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -333,8 +333,10 @@ module OAuth
       end
 
       # if the base site contains a path, add it now
+      # only add if the site host matches the current http object's host
+      # (in case we've specified a full url for token requests)
       uri = URI.parse(site)
-      path = uri.path + path if uri.path && uri.path != '/'
+      path = uri.path + path if uri.path && uri.path != '/' && uri.host == http.address
 
       headers = arguments.first.is_a?(Hash) ? arguments.shift : {}
 

--- a/test/test_consumer.rb
+++ b/test/test_consumer.rb
@@ -69,7 +69,7 @@ class ConsumerTest < Test::Unit::TestCase
           :site=>"http://twitter.com"
       })
     request = stub(:oauth! => nil)
-    http = stub(:request => stub(:to_hash => {}))
+    http = stub(:request => stub(:to_hash => {}), :address => "identi.ca")
     Net::HTTP::Get.expects(:new).with('/people', {}).returns(request)
     @consumer.expects(:create_http).returns(http)
     @consumer.request(:get, '/people', nil, {})
@@ -83,7 +83,7 @@ class ConsumerTest < Test::Unit::TestCase
           :site=>"http://identi.ca/api"
       })
     request = stub(:oauth! => nil)
-    http = stub(:request => stub(:to_hash => {}))
+    http = stub(:request => stub(:to_hash => {}), :address => "identi.ca")
     Net::HTTP::Get.expects(:new).with('/api/people', {}).returns(request)
     @consumer.expects(:create_http).returns(http)
     @consumer.request(:get, '/people', nil, {})
@@ -130,6 +130,19 @@ class ConsumerTest < Test::Unit::TestCase
     assert_equal "http://site.twitter.com/authorize",@consumer.authorize_url
     assert_equal :header,@consumer.scheme
     assert_equal :post,@consumer.http_method
+  end
+
+  def test_getting_tokens_doesnt_add_paths_if_full_url_is_specified
+    @consumer = OAuth::Consumer.new(
+      "key",
+      "secret",
+      {
+          :site              => "https://api.mysite.co.nz/v1",
+          :request_token_url => "https://authentication.mysite.co.nz/Oauth/RequestToken"
+      })
+
+    stub_request(:post, "https://authentication.mysite.co.nz/Oauth/RequestToken").to_return(:status => 200)
+    @consumer.get_request_token
   end
 
  def test_that_token_response_should_be_uri_parameter_format_as_default


### PR DESCRIPTION
When you create a consumer similar to the following:

```ruby
    @consumer = OAuth::Consumer.new(
      "key",
      "secret",
      {
          :site              => "https://api.mysite.co.nz/v1",
          :request_token_url => "https://authentication.mysite.co.nz/Oauth/RequestToken"
      })
```

Then currently the #get_request_token method will send a request to:

http://authentication.mysite.co.nz/v1/Oauth/RequestToken

(Note the extra "v1" path)

This is due to this line: 

https://github.com/oauth/oauth-ruby/blob/master/lib/oauth/consumer.rb#L337

This patch:

  * Changes that functionality so that it's only active if the current http host and the URI host match
  * Adds a test for the broken case

All the tests pass, so I don't think I've missed anything but let me know if I have and I'll be happy to update the PR.

Thanks!

Nik