### PR TITLE
Avoid circular require warning under Ruby 1.9.2

### DIFF
--- a/lib/oauth/client/helper.rb
+++ b/lib/oauth/client/helper.rb
@@ -1,5 +1,4 @@
 require 'oauth/client'
-require 'oauth/consumer'
 require 'oauth/helper'
 require 'oauth/token'
 require 'oauth/signature/hmac/sha1'


### PR DESCRIPTION
Removed a require consumer so that there is no more circular require warning under Ruby 1.9.2