### PR TITLE
Correct verify

### DIFF
--- a/lib/oauth/signature/base.rb
+++ b/lib/oauth/signature/base.rb
@@ -66,7 +66,7 @@ module OAuth::Signature
     end
 
     def ==(cmp_signature)
-      Base64.decode64(signature) == Base64.decode64(cmp_signature)
+      signature == cmp_signature
     end
 
     def verify

--- a/test/test_signature_hmac_sha1.rb
+++ b/test/test_signature_hmac_sha1.rb
@@ -1,0 +1,40 @@
+require File.expand_path('../test_helper', __FILE__)
+require 'oauth/signature/hmac/sha1'
+
+class SignatureHMACSHA1Test < Test::Unit::TestCase
+  def test_that_verify_returns_true_when_the_request_signature_is_right
+    request = OAuth::RequestProxy::MockRequest.new(
+      'method' => 'POST',
+      'uri' => 'https://photos.example.net/initialize',
+      'parameters' => {
+        'oauth_consumer_key' => 'dpf43f3p2l4k3l03',
+        'oauth_signature_method' => 'HMAC-SHA1',
+        'oauth_timestamp' => '137131200',
+        'oauth_nonce' => 'wIjqoS',
+        'oauth_callback' => 'http://printer.example.com/ready',
+        'oauth_version' => '1.0',
+        'oauth_signature' => 'xcHYBV3AbyoDz7L4dV10P3oLCjY='
+      }
+    )
+    assert OAuth::Signature::HMAC::SHA1.new(request, :consumer_secret => 'kd94hf93k423kf44').verify
+  end
+
+  def test_that_verify_returns_false_when_the_request_signature_is_wrong
+    # Test a bug in the OAuth::Signature::Base#== method: when the Base64.decode64 method is
+    # used on the "self" and "other" signature (as in version 0.4.7), the result may be incorrectly "true".
+    request = OAuth::RequestProxy::MockRequest.new(
+      'method' => 'POST',
+      'uri' => 'https://photos.example.net/initialize',
+      'parameters' => {
+        'oauth_consumer_key' => 'dpf43f3p2l4k3l03',
+        'oauth_signature_method' => 'HMAC-SHA1',
+        'oauth_timestamp' => '137131200',
+        'oauth_nonce' => 'wIjqoS',
+        'oauth_callback' => 'http://printer.example.com/ready',
+        'oauth_version' => '1.0',
+        'oauth_signature' => 'xcHYBV3AbyoDz7L4dV10P3oLCjZ='
+      }
+    )
+    assert !OAuth::Signature::HMAC::SHA1.new(request, :consumer_secret => 'kd94hf93k423kf44').verify
+  end
+end


### PR DESCRIPTION
The `OAuth::Signature::Base#==` method currently incorrectly returns `true` even when the signature from the request does not match. See e.g. the test case in this pull request, the correct signature is `xcHYBV3AbyoDz7L4dV10P3oLCjY=` and current implementation verifies a different signature `xcHYBV3AbyoDz7L4dV10P3oLCjZ=` as also correct. This may be a security risk for OAuth servers using the `OAuth::Signature::Base#==` or `OAuth::Signature::Base#verify` methods to verify signatures submitted by clients.

Problem goes away when comparing the signatures instead of comparing the results of `Base64.decode64(signature)`.