### PR TITLE
Standardize read/open timeout option names

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -318,7 +318,7 @@ module OAuth
         http_object.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 
-      http_object.read_timeout = http_object.open_timeout = @options[:timeout] || 30
+      http_object.read_timeout = @options[:read_timeout] if @options[:read_timeout]
       http_object.open_timeout = @options[:open_timeout] if @options[:open_timeout]
 
       http_object


### PR DESCRIPTION
read_timeout and open_timeout are the standard names for setting the timeouts.

Remove the customer :timeout setting and don't set a default (let Ruby set it's own).

Also, don't set open_timeout to read_timeout, since the two do different things.