### PR TITLE
Change oauth_secret to oauth_token_secret

### DIFF
--- a/lib/oauth/tokens/token.rb
+++ b/lib/oauth/tokens/token.rb
@@ -11,7 +11,7 @@ module OAuth
     end
 
     def to_query
-      "oauth_token=#{escape(token)}&oauth_secret=#{escape(secret)}"
+      "oauth_token=#{escape(token)}&oauth_token_secret=#{escape(secret)}"
     end
   end
 end


### PR DESCRIPTION
`Token.to_query()` uses the nonstandard `oauth_secret` key. I changed this to `oauth_token_secret` to match the [OAuth Spec](http://oauth.net/core/1.0/#rfc.section.6.1.2).

With this change, `Token.to_query()` returns a valid response for a token request.