### PR TITLE
undefined method `downcase' for :post:Symbol (NoMethodError)

### DIFF
--- a/lib/oauth/cli.rb
+++ b/lib/oauth/cli.rb
@@ -107,7 +107,7 @@ module OAuth
           uri.query = [uri.query, *params].reject { |x| x.nil? } * "&"
           p uri.to_s
 
-          response = access_token.request(options[:method].downcase.to_sym, uri.to_s)
+          response = access_token.request(options[:method].to_s.downcase.to_sym, uri.to_s)
           puts "#{response.code} #{response.message}"
           puts response.body
         when "sign"


### PR DESCRIPTION
```shell
# Original exception
usr/lib64/ruby/gems/1.8/gems/oauth-0.4.7/lib/oauth/cli.rb:110:in `execute': undefined method `downcase' for :post:Symbol (NoMethodError)
	from /usr/lib64/ruby/gems/1.8/gems/oauth-0.4.7/lib/oauth/cli.rb:19:in `execute'
	from /usr/lib64/ruby/gems/1.8/gems/oauth-0.4.7/bin/oauth:5
	from /usr/bin/oauth:23:in `load'
	from /usr/bin/oauth:23
```

make sure the `options[:method]` is converted to a string before using downcase