### PR TITLE
Rails 3+ / ActiveSupport::SafeBuffer patch

### DIFF
--- a/lib/oauth/helper.rb
+++ b/lib/oauth/helper.rb
@@ -9,9 +9,9 @@ module OAuth
     #
     # See Also: {OAuth core spec version 1.0, section 5.1}[http://oauth.net/core/1.0#rfc.section.5.1]
     def escape(value)
-      URI::escape(value.to_s, OAuth::RESERVED_CHARACTERS)
+      URI::escape(value.to_s.to_str, OAuth::RESERVED_CHARACTERS)
     rescue ArgumentError
-      URI::escape(value.to_s.force_encoding(Encoding::UTF_8), OAuth::RESERVED_CHARACTERS)
+      URI::escape(value.to_s.to_str, force_encoding(Encoding::UTF_8), OAuth::RESERVED_CHARACTERS)
     end
 
     # Generate a random key of up to +size+ bytes. The value returned is Base64 encoded with non-word

--- a/lib/oauth/helper.rb
+++ b/lib/oauth/helper.rb
@@ -11,7 +11,7 @@ module OAuth
     def escape(value)
       URI::escape(value.to_s.to_str, OAuth::RESERVED_CHARACTERS)
     rescue ArgumentError
-      URI::escape(value.to_s.to_str, force_encoding(Encoding::UTF_8), OAuth::RESERVED_CHARACTERS)
+      URI::escape(value.to_s.to_str.force_encoding(Encoding::UTF_8), OAuth::RESERVED_CHARACTERS)
     end
 
     # Generate a random key of up to +size+ bytes. The value returned is Base64 encoded with non-word


### PR DESCRIPTION
Previously, if an Oauth code path was executed in a Rails controller, it would result in these `to_s` methods to return an ActiveSupport::SafeBuffer object, rather than String - which causes problems in the URI library and ends up raising an error.

This change should be also be compatible with non-Rails environments as well:

    irb(main):001:0> ActiveSupport::SafeBuffer.new("foo").to_s.to_str.class
    => String
    irb(main):002:0> String.new("bar").to_s.to_str.class
    => String
    irb(main):003:0> nil.to_s.to_str.class
    => String