### PR TITLE
Fix token requests do not include oauth_body_hash

### DIFF
--- a/lib/oauth/client/helper.rb
+++ b/lib/oauth/client/helper.rb
@@ -56,6 +56,10 @@ module OAuth::Client
                                                          :parameters => oauth_parameters}.merge(extra_options) )
     end
 
+    def token_request?
+      @options[:token_request].eql?(true)
+    end
+
     def hash_body
       @options[:body_hash] = OAuth::Signature.body_hash(@request, :parameters => oauth_parameters)
     end

--- a/lib/oauth/client/net_http.rb
+++ b/lib/oauth/client/net_http.rb
@@ -21,7 +21,8 @@ class Net::HTTPGenericRequest
   # This method also modifies the <tt>User-Agent</tt> header to add the OAuth gem version.
   #
   # See Also: {OAuth core spec version 1.0, section 5.4.1}[http://oauth.net/core/1.0#rfc.section.5.4.1],
-  #           {OAuth Request Body Hash 1.0 Draft 4}[http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/drafts/4/spec.html]
+  #           {OAuth Request Body Hash 1.0 Draft 4}[http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/drafts/4/spec.html,
+  #                                                 http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html#when_to_include]
   def oauth!(http, consumer = nil, token = nil, options = {})
     helper_options = oauth_helper_options(http, consumer, token, options)
     @oauth_helper = OAuth::Client::Helper.new(self, helper_options)
@@ -42,8 +43,9 @@ class Net::HTTPGenericRequest
   # * options - Request-specific options (e.g. +request_uri+, +consumer+, +token+, +scheme+,
   #   +signature_method+, +nonce+, +timestamp+)
   #
-  # See Also: {OAuth core spec version 1.0, section 9.1.1}[http://oauth.net/core/1.0#rfc.section.9.1.1],
-  #           {OAuth Request Body Hash 1.0 Draft 4}[http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/drafts/4/spec.html]
+  # See Also: {OAuth core spec version 1.0, section 5.4.1}[http://oauth.net/core/1.0#rfc.section.5.4.1],
+  #           {OAuth Request Body Hash 1.0 Draft 4}[http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/drafts/4/spec.html,
+  #                                                 http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html#when_to_include]
   def signature_base_string(http, consumer = nil, token = nil, options = {})
     helper_options = oauth_helper_options(http, consumer, token, options)
     @oauth_helper = OAuth::Client::Helper.new(self, helper_options)

--- a/lib/oauth/client/net_http.rb
+++ b/lib/oauth/client/net_http.rb
@@ -46,9 +46,9 @@ class Net::HTTPGenericRequest
   #           {OAuth Request Body Hash 1.0 Draft 4}[http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/drafts/4/spec.html]
   def signature_base_string(http, consumer = nil, token = nil, options = {})
     helper_options = oauth_helper_options(http, consumer, token, options)
-    oauth_helper = OAuth::Client::Helper.new(self, helper_options)
-    oauth_helper.hash_body if oauth_body_hash_required?
-    oauth_helper.signature_base_string
+    @oauth_helper = OAuth::Client::Helper.new(self, helper_options)
+    @oauth_helper.hash_body if oauth_body_hash_required?
+    @oauth_helper.signature_base_string
   end
 
 private
@@ -84,7 +84,7 @@ private
   end
 
   def oauth_body_hash_required?
-    request_body_permitted? && !content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
+    !@oauth_helper.token_request? && request_body_permitted? && !content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
   end
 
   def set_oauth_header

--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -235,8 +235,8 @@ module OAuth
     end
 
     def request_endpoint
-  return nil if @options[:request_endpoint].nil?
-  @options[:request_endpoint].to_s
+      return nil if @options[:request_endpoint].nil?
+      @options[:request_endpoint].to_s
     end
 
     def scheme

--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -191,6 +191,7 @@ module OAuth
 
     # Creates a request and parses the result as url_encoded. This is used internally for the RequestToken and AccessToken requests.
     def token_request(http_method, path, token = nil, request_options = {}, *arguments)
+      request_options[:token_request] ||= true
       response = request(http_method, path, token, request_options, *arguments)
       case response.code.to_i
 

--- a/test/test_consumer.rb
+++ b/test/test_consumer.rb
@@ -131,7 +131,14 @@ class ConsumerTest < Test::Unit::TestCase
     assert_equal :post,@consumer.http_method
   end
 
- def test_that_token_response_should_be_uri_parameter_format_as_default
+  def test_token_request_identifies_itself_as_a_token_request
+    request_options = {}
+    @consumer.stubs(:request).returns(create_stub_http_response)
+    @consumer.token_request(:post, '/', 'token', request_options) {}
+    assert_equal true, request_options[:token_request]
+  end
+
+  def test_that_token_response_should_be_uri_parameter_format_as_default
     @consumer.expects(:request).returns(create_stub_http_response("oauth_token=token&oauth_token_secret=secret"))
 
     hash = @consumer.token_request(:get, "")

--- a/test/test_net_http_client.rb
+++ b/test/test_net_http_client.rb
@@ -62,6 +62,12 @@ class NetHTTPClientTest < Test::Unit::TestCase
     assert_matching_headers "oauth_nonce=\"225579211881198842005988698334675835446\", oauth_body_hash=\"oXyaqmHoChv3HQ2FCvTluqmAC70%3D\", oauth_signature_method=\"HMAC-SHA1\", oauth_token=\"token_411a7f\", oauth_timestamp=\"1199645624\", oauth_consumer_key=\"consumer_key_86cad9\", oauth_signature=\"0DA6pGTapdHSqC15RZelY5rNLDw%3D\", oauth_version=\"1.0\"", request['authorization']
   end
 
+  def test_that_body_hash_is_obmitted_when_token_request
+    request = Net::HTTP::Post.new(@request_uri.path)
+    request.oauth!(@http, @consumer, @token, {:nonce => @nonce, :timestamp => @timestamp, :token_request => true})
+    assert_no_match(/oauth_body_hash/, request['authorization'])
+  end
+
   def test_that_body_hash_is_obmitted_when_no_algorithm_is_defined
     request = Net::HTTP::Post.new(@request_uri.path)
     request.body = "data"


### PR DESCRIPTION
While updating integration code I ran into some trouble with oauth requests returning 500, which I traced back to the inclusion of `oauth_body_hash` in the access token request. 

The [specs here](http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html#when_to_include) indicate, that while it's not quite criminal, it could cause some api's to reject the request. So I pulled it out, just to see what would happen, and the request was successful.

I wasn't able to locate an existing solution or work around for this.