### PR TITLE
Update consumer.rb - move to new convention

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -10,7 +10,7 @@ module OAuth
     # determine the certificate authority path to verify SSL certs
     CA_FILES = %w(/etc/ssl/certs/ca-certificates.crt /usr/share/curl/curl-ca-bundle.crt)
     CA_FILES.each do |ca_file|
-      if File.exists?(ca_file)
+      if File.exist?(ca_file)
         CA_FILE = ca_file
         break
       end


### PR DESCRIPTION
`File.exists?` is deprecated in favor of `File.exist?`.