### PR TITLE
use system settings for cert file, not hardcoded path

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -8,7 +8,7 @@ require 'cgi'
 module OAuth
   class Consumer
     # determine the certificate authority path to verify SSL certs
-    CA_FILES = %w(/etc/ssl/certs/ca-certificates.crt /usr/share/curl/curl-ca-bundle.crt)
+    CA_FILES = %W(#{OpenSSL::X509::DEFAULT_CERT_FILE} /usr/share/curl/curl-ca-bundle.crt)
     CA_FILES.each do |ca_file|
       if File.exists?(ca_file)
         CA_FILE = ca_file


### PR DESCRIPTION
Some systems are using another path for SSL keys like OPENSSLDIR: "/etc/pki/tls" (CentOS). Better way will be not to use hardcoded file paths, but system settings