### PR TITLE
added possible paths for cert files

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -8,7 +8,7 @@ require 'cgi'
 module OAuth
   class Consumer
     # determine the certificate authority path to verify SSL certs
-    CA_FILES = %w(/etc/ssl/certs/ca-certificates.crt /usr/share/curl/curl-ca-bundle.crt)
+    CA_FILES = %W(#{ENV['SSL_CERT_FILE']} /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt /usr/share/curl/curl-ca-bundle.crt)
     CA_FILES.each do |ca_file|
       if File.exists?(ca_file)
         CA_FILE = ca_file


### PR DESCRIPTION
On some systems certificate file could be placed in different directories. That could cause unexpected errors. Added usage of environment variable and one more file path, used in centos.