### PR TITLE
fix regression by guarding against URI::Generic.query being nil

### DIFF
--- a/lib/oauth/tokens/request_token.rb
+++ b/lib/oauth/tokens/request_token.rb
@@ -26,7 +26,7 @@ module OAuth
     # construct an authorization url
     def build_authorize_url(base_url, params)
       uri = URI.parse(base_url.to_s)
-      if(!uri.query.blank? && !params.empty?)
+      if(uri.query && !uri.query.blank? && !params.empty?)
 	uri.query += "&"
       end
       # TODO doesn't handle array values correctly


### PR DESCRIPTION
URI::Generic.query defaults to nil if there is no query part in the parsed
string, so make sure we don't call methods on nil.

This fixes the already existing request_token tests of which 3/5 are
failing with:
> NoMethodError: undefined method `blank?' for nil:NilClass