### PR TITLE
Fixed broken method.

### DIFF
--- a/lib/oauth/tokens/request_token.rb
+++ b/lib/oauth/tokens/request_token.rb
@@ -26,11 +26,11 @@ module OAuth
     # construct an authorization url
     def build_authorize_url(base_url, params)
       uri = URI.parse(base_url.to_s)
-      if(uri.query && !uri.query.blank? && !params.empty?)
-	uri.query += "&"
-      end
+      queries = {}
+      queries = Hash[URI.decode_www_form(uri.query)] if uri.query
       # TODO doesn't handle array values correctly
-      uri.query = params.map { |k,v| [k, CGI.escape(v)] * "=" } * "&"
+      queries.merge!(params) if params
+      uri.query = URI.encode_www_form(queries) if !queries.empty?
       uri.to_s
     end
   end


### PR DESCRIPTION
`build_authorize_url` tried to invoke a method called `blank?` against `uri.query` , apparently trying to guard against the empty string. Although `blank?` is defined for strings in Rails, it is not defined in stock Ruby, causing `build_authorize_url` to fail.  I fixed the problem by converting the query string to a Hash object using the standard library, rather than trying to manually manipulate the query string.