### PR TITLE
Replace String#blank? with its implementation

### DIFF
--- a/lib/oauth/request_proxy/action_controller_request.rb
+++ b/lib/oauth/request_proxy/action_controller_request.rb
@@ -67,7 +67,7 @@ module OAuth::RequestProxy
 
       params.
         join('&').split('&').
-        reject(&:blank?).
+        reject { |s| s.match(/\A\s*\z/) }.
         map { |p| p.split('=').map{|esc| CGI.unescape(esc)} }.
         reject { |kv| kv[0] == 'oauth_signature'}
     end

--- a/lib/oauth/request_proxy/base.rb
+++ b/lib/oauth/request_proxy/base.rb
@@ -146,7 +146,7 @@ module OAuth::RequestProxy
       if uri = request.env['REQUEST_URI']
         uri.split('?', 2)[1].nil?
       else
-        request.query_string.blank?
+        request.query_string.match(/\A\s*\z/)
       end
     end
 


### PR DESCRIPTION
Running a small app I was getting a `NoMethodError: undefined method 'blank?' for nil:NilClass`. Adding a `require 'active_support/core_ext/object/blank'` would fix it, I guess it's a hidden dependency, not surfaced by the tests because ActiveSupport is a development dependency.

A possible solution is adding that dependency, but there are only two instances of `blank?` so I thought it would be better to just replace the call with the equivalent implementation.

Note 1: ActiveSupport's `blank?` also checks for `nil?` but in this two cases it is guaranteed to be a `String` (one is called on the items returned by `String#split`, the other one on `Rack::Request#query_string` which ends up with a `#to_s`).
Note 2: <s>Not sure if this is a duplicate of #108.</s> No, I don't think so. I *think* the error I was getting in my app was caused by the call to `blank?` fixed there, but I guess this other two have to be fixed too.