### PR TITLE
Silencing a warning for ivar not initialized

### DIFF
--- a/test/cases/oauth_case.rb
+++ b/test/cases/oauth_case.rb
@@ -6,6 +6,7 @@ require 'oauth/request_proxy/mock_request'
 class OAuthCase < Minitest::Test
   # avoid whining about a lack of tests
   def run(*args)
+    @method_name ||= nil
     return if @method_name.to_s == "default_test"
     super
   end


### PR DESCRIPTION
Silencing 'oauth-ruby/test/cases/oauth_case.rb:9: warning: instance variable @method_name not initialized'