### PR TITLE
Silencing 'loading in progress, circular require considered harmful'

### DIFF
--- a/lib/oauth/client/action_controller_request.rb
+++ b/lib/oauth/client/action_controller_request.rb
@@ -1,4 +1,3 @@
-require 'oauth/client/helper'
 if defined? ActionDispatch
   require 'oauth/request_proxy/rack_request'
   require 'action_dispatch/testing/test_process'

--- a/lib/oauth/client/em_http.rb
+++ b/lib/oauth/client/em_http.rb
@@ -1,6 +1,5 @@
 require 'em-http'
 require 'oauth/helper'
-require 'oauth/client/helper'
 require 'oauth/request_proxy/em_http_request'
 
 # Extensions for em-http so that we can use consumer.sign! with an EventMachine::HttpClient

--- a/lib/oauth/client/net_http.rb
+++ b/lib/oauth/client/net_http.rb
@@ -1,5 +1,4 @@
 require 'oauth/helper'
-require 'oauth/client/helper'
 require 'oauth/request_proxy/net_http'
 
 class Net::HTTPGenericRequest


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/335238/15450428/872733dc-1f71-11e6-9d74-aea852f780d6.png)

```
/Users/tj/github/opensource/oauth-ruby/lib/oauth/client/net_http.rb:2: warning: loading in progress, circular require considered harmful - /Users/tj/github/opensource/oauth-ruby/lib/oauth/client/helper.rb
  from /Users/tj/.rvm/gems/ruby-2.3.0/gems/rake-11.1.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
  from /Users/tj/.rvm/gems/ruby-2.3.0/gems/rake-11.1.2/lib/rake/rake_test_loader.rb:4:in  `select'
  from /Users/tj/.rvm/gems/ruby-2.3.0/gems/rake-11.1.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
  from /Users/tj/.rvm/gems/ruby-2.3.0/gems/rake-11.1.2/lib/rake/rake_test_loader.rb:15:in  `require'
  from /Users/tj/github/opensource/oauth-ruby/test/integration/consumer_test.rb:1:in  `<top (required)>'
  from /Users/tj/github/opensource/oauth-ruby/test/integration/consumer_test.rb:1:in  `require'
  from /Users/tj/github/opensource/oauth-ruby/test/test_helper.rb:14:in  `<top (required)>'
  from /Users/tj/github/opensource/oauth-ruby/test/test_helper.rb:14:in  `require'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth.rb:9:in  `<top (required)>'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth.rb:9:in  `require'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth/client/helper.rb:2:in  `<top (required)>'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth/client/helper.rb:2:in  `require'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth/consumer.rb:4:in  `<top (required)>'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth/consumer.rb:4:in  `require'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth/client/net_http.rb:2:in  `<top (required)>'
  from /Users/tj/github/opensource/oauth-ruby/lib/oauth/client/net_http.rb:2:in  `require'

```