### PR TITLE
Silencing 'Net::HTTPResponse#header is obsolete'

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -229,7 +229,7 @@ module OAuth
         end
       when (300..399)
         # this is a redirect
-        uri = URI.parse(response.header['location'])
+        uri = URI.parse(response['location'])
         response.error! if uri.path == path # careful of those infinite redirects
         self.token_request(http_method, uri.path, token, request_options, arguments)
       when (400..499)


### PR DESCRIPTION
One less warning