### PR TITLE
Rails 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 pkg/*
 _site
 .bundle
-Gemfile.lock
+Gemfile*.lock
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,22 @@ addons:
 
 language: ruby
 
-before_install: rvm rubygems master --force
-install: gem install --file
-script: "RUBYGEMS_GEMDEPS=- rake test"
-
 rvm:
-- "2.3.0"
-- "2.2"
-- "2.1"
-- "2.0"
+- 2.3.1
+- 2.2.5
+- 2.1
+- 2.0
+
+gemfile:
+- gemfiles/Gemfile.rails-4
+- Gemfile
+
+matrix:
+  exclude:
+  - rvm: 2.0
+    gemfile: Gemfile
+  - rvm: 2.1
+    gemfile: Gemfile
 
 addons:
   code_climate:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :test do
-  gem "codeclimate-test-reporter", require: nil
-end

--- a/gemfiles/Gemfile.rails-4
+++ b/gemfiles/Gemfile.rails-4
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'actionpack', '< 5'
+gem 'rack', '< 2'

--- a/oauth.gemspec
+++ b/oauth.gemspec
@@ -20,15 +20,16 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = [ "LICENSE", "README.rdoc", "TODO" ]
 
   spec.add_development_dependency("rake")
-  spec.add_development_dependency("minitest")
+  spec.add_development_dependency("minitest", '>= 5.0')
   spec.add_development_dependency("byebug")
-  spec.add_development_dependency("actionpack", ">= 5.0.0") # TODO: try to allow both Rails versions on next release
+  spec.add_development_dependency("actionpack")
   spec.add_development_dependency("iconv")
-  spec.add_development_dependency("rack", "~> 1.0") # TODO: try to allow both Rack versions on next release
+  spec.add_development_dependency("rack")
   spec.add_development_dependency("rack-test")
   spec.add_development_dependency("mocha", ">= 0.9.12")
   spec.add_development_dependency("typhoeus", ">= 0.1.13")
   spec.add_development_dependency("em-http-request", "0.2.11")
   spec.add_development_dependency("curb")
   spec.add_development_dependency("webmock", "< 2.0")
+  spec.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/test/units/test_action_controller_request_proxy.rb
+++ b/test/units/test_action_controller_request_proxy.rb
@@ -1,11 +1,12 @@
 require File.expand_path('../../test_helper_units', __FILE__)
 
 require 'oauth/request_proxy/action_controller_request'
+require 'rack/mock'
 
 class ActionControllerRequestProxyTest < Minitest::Test
 
   def request_proxy(request_method = :get, uri_params = {}, body_params = {})
-    request = ActionDispatch::TestRequest.new
+    request = ActionDispatch::TestRequest.new(Rack::MockRequest.env_for('/', method: request_method, params: uri_params))
     request.request_uri = '/'
 
     case request_method


### PR DESCRIPTION
Updates the existing `rails5` branch to pass the test suite.

I added an extra `Gemfile` and modified the `travis.yml` to run tests against the previous major versions of `rack` (`1.x.x`) and `actionpack` (`4.x.x`) in addition to the latest versions (`rack 2.x.x` / `actionpack 5.x.x`), to ensure compatibility with both sets of dependencies.
