### PR TITLE
Require plaintext signature method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
 
 language: ruby
 
-before_install: rvm rubygems master --force
+before_install: rvm rubygems v2.6.6 --force
 install: gem install --file
 script: "RUBYGEMS_GEMDEPS=- rake test"
 

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -7,6 +7,7 @@ require 'oauth/oauth'
 require 'oauth/core_ext'
 
 require 'oauth/client/helper'
+require 'oauth/signature/plaintext'
 require 'oauth/signature/hmac/sha1'
 require 'oauth/signature/rsa/sha1'
 require 'oauth/request_proxy/mock_request'

--- a/test/integration/consumer_test.rb
+++ b/test/integration/consumer_test.rb
@@ -32,7 +32,6 @@ module Integration
     end
 
     def test_that_setting_signature_method_on_consumer_effects_signing
-      require 'oauth/signature/plaintext'
       request = Net::HTTP::Get.new(@request_uri.path)
       consumer = @consumer.dup
       consumer.options[:signature_method] = 'PLAINTEXT'
@@ -44,7 +43,6 @@ module Integration
     end
 
     def test_that_setting_signature_method_on_consumer_effects_signature_base_string
-      require 'oauth/signature/plaintext'
       request = Net::HTTP::Get.new(@request_uri.path)
       consumer = @consumer.dup
       consumer.options[:signature_method] = 'PLAINTEXT'
@@ -58,7 +56,7 @@ module Integration
 
     def test_that_plaintext_signature_works
       # Invalid test because server expects double-escaped signature
-      require 'oauth/signature/plaintext'
+
       # consumer = OAuth::Consumer.new("key", "secret",
       #   :site => "http://term.ie", :signature_method => 'PLAINTEXT')
       # access_token = OAuth::AccessToken.new(consumer, 'accesskey', 'accesssecret')

--- a/test/units/test_em_http_client.rb
+++ b/test/units/test_em_http_client.rb
@@ -27,7 +27,6 @@ class EmHttpClientTest < Minitest::Test
   end
 
   def test_that_using_auth_headers_on_get_requests_works_with_plaintext
-    require 'oauth/signature/plaintext'
     c = OAuth::Consumer.new('consumer_key_86cad9', '5888bf0345e5d237',{
       :signature_method => 'PLAINTEXT'
     })

--- a/test/units/test_net_http_client.rb
+++ b/test/units/test_net_http_client.rb
@@ -25,7 +25,6 @@ class NetHTTPClientTest < Minitest::Test
   end
 
   def test_that_using_auth_headers_on_get_requests_works_with_plaintext
-    require 'oauth/signature/plaintext'
     c = OAuth::Consumer.new('consumer_key_86cad9', '5888bf0345e5d237',{
       :signature_method => 'PLAINTEXT'
     })

--- a/test/units/test_signature_plain_text.rb
+++ b/test/units/test_signature_plain_text.rb
@@ -1,5 +1,4 @@
 require File.expand_path('../../test_helper_units', __FILE__)
-require 'oauth/signature/plaintext'
 
 class TestSignaturePlaintext < Minitest::Test
   def test_that_plaintext_implements_plaintext


### PR DESCRIPTION
For some reason the plaintext signature class is not `require`'d by default, and cannot be used without explicitly requiring it. This has historically been so, and the tests go out of their way to manually require the class: https://github.com/oauth-xx/oauth-ruby/blob/705ae93/test/units/test_net_http_client.rb#L28. I have no idea why this choice has been made.

Last year in issue #76 some users bumped their head against this. This should either be documented, or the class should just be required.

This pull request adds the require statement and removes all the require statements from the tests.

I also modified travis.yml to use a specific rubygems version, because master is probably broken (https://github.com/rubygems/rubygems/issues/1679) and it can break in the future. The Travis CI default (v2.5.1) unfortunately is broken as well (https://github.com/rubygems/rubygems/issues/1223).
