### PR TITLE
Upgrade Code Climate and fixing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-addons:
-  apt:
-    packages:
-      - libcurl-dev
-
 language: ruby
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ addons:
 
 language: ruby
 
-before_install: rvm rubygems master --force
-install: gem install --file
-script: "RUBYGEMS_GEMDEPS=- rake test"
-
 rvm:
-- "2.3.0"
+- "ruby-head"
+- "2.4.0"
+- "2.3"
 - "2.2"
 - "2.1"
 - "2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 addons:
   apt:
     packages:
-    - libcurl-dev
+      - libcurl-dev
 
 language: ruby
 
@@ -16,3 +16,6 @@ rvm:
 addons:
   code_climate:
     repo_token: 8f697ca756250f0c2c54170ae27e8a9c459d18a0236903b11291c88291b3aac9
+
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :test do
-  gem "codeclimate-test-reporter", require: nil
-end

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 === CURRENT
 
 * Adding support to Ruby 2.4 and head (James Pinto)
+* Upgrading to CodeClimate 1.0 (James Pinto)
 
 === 0.5.1 2016-02-29
 

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,7 @@
+=== CURRENT
+
+* Adding support to Ruby 2.4 and head (James Pinto)
+
 === 0.5.1 2016-02-29
 
 * Proper handling for empty query string in RequestToken#build_authorize_url (midchildan,

--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,7 @@
 
 * Adding support to Ruby 2.4 and head (James Pinto)
 * Upgrading to CodeClimate 1.0 (James Pinto)
+* Nokogiri 1.7 does not accept Ruby 2.0 (James Pinto)
 
 === 0.5.1 2016-02-29
 

--- a/oauth.gemspec
+++ b/oauth.gemspec
@@ -19,6 +19,12 @@ Gem::Specification.new do |spec|
   spec.test_files  = Dir.glob("test/**/*.rb")
   spec.extra_rdoc_files = [ "LICENSE", "README.rdoc", "TODO" ]
 
+  # This gem will work with 2.0 or greater...
+  spec.required_ruby_version = '>= 2.0'
+
+  # Nokogiri 1.7 does not accept Ruby 2.0
+  spec.add_development_dependency("nokogiri", "~> 1.6.8") if RUBY_VERSION < "2.1"
+
   spec.add_development_dependency("rake")
   spec.add_development_dependency("minitest")
   spec.add_development_dependency("byebug")

--- a/oauth.gemspec
+++ b/oauth.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("em-http-request", "0.2.11")
   spec.add_development_dependency("curb")
   spec.add_development_dependency("webmock", "< 2.0")
+  spec.add_development_dependency("codeclimate-test-reporter")
+  spec.add_development_dependency("simplecov")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 ENV['RACK_ENV'] = 'test'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require 'rubygems'
 require 'minitest/autorun'
@@ -14,6 +14,5 @@ $LOAD_PATH << File.dirname(__FILE__) + '/../lib/'
 require 'oauth'
 require 'stringio'
 require 'webmock/minitest'
-WebMock.disable_net_connect!(allow: "codeclimate.com")
 
 require 'support/minitest_helpers'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,18 +1,26 @@
+# ensure test env
+
 ENV['RACK_ENV'] = 'test'
+
+# simplecov, Travis will call codeclimate
 
 require 'simplecov'
 SimpleCov.start
 
-require 'rubygems'
+# require third-party code
+
+require 'byebug'
+require 'stringio'
 require 'minitest/autorun'
 require 'mocha/mini_test'
 require 'rack/test'
+require 'webmock/minitest'
 
-require 'byebug'
+# require our lib
 
 $LOAD_PATH << File.dirname(__FILE__) + '/../lib/'
 require 'oauth'
-require 'stringio'
-require 'webmock/minitest'
+
+# require our support code
 
 require 'support/minitest_helpers'

--- a/test/test_helper_units.rb
+++ b/test/test_helper_units.rb
@@ -1,1 +1,0 @@
-require 'test_helper'

--- a/test/units/test_access_token.rb
+++ b/test/units/test_access_token.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class TestAccessToken < Minitest::Test
   def setup

--- a/test/units/test_action_controller_request_proxy.rb
+++ b/test/units/test_action_controller_request_proxy.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 require 'oauth/request_proxy/action_controller_request'
 

--- a/test/units/test_cli.rb
+++ b/test/units/test_cli.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 require 'oauth/cli'
 

--- a/test/units/test_consumer.rb
+++ b/test/units/test_consumer.rb
@@ -1,6 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
-
-require 'stringio'
+require File.expand_path('../../test_helper', __FILE__)
 
 # This performs testing against Andy Smith's test server http://term.ie/oauth/example/
 # Thanks Andy.

--- a/test/units/test_curb_request_proxy.rb
+++ b/test/units/test_curb_request_proxy.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 begin
 

--- a/test/units/test_em_http_client.rb
+++ b/test/units/test_em_http_client.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 begin
 
 require 'oauth/client/em_http'

--- a/test/units/test_em_http_request_proxy.rb
+++ b/test/units/test_em_http_request_proxy.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 begin
 

--- a/test/units/test_hmac_sha1.rb
+++ b/test/units/test_hmac_sha1.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class TestSignatureHmacSha1 < Minitest::Test
   def test_that_hmac_sha1_implements_hmac_sha1

--- a/test/units/test_net_http_client.rb
+++ b/test/units/test_net_http_client.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class NetHTTPClientTest < Minitest::Test
 

--- a/test/units/test_net_http_request_proxy.rb
+++ b/test/units/test_net_http_request_proxy.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class NetHTTPRequestProxyTest < Minitest::Test
 

--- a/test/units/test_oauth_helper.rb
+++ b/test/units/test_oauth_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class TestOAuthHelper < Minitest::Test
 

--- a/test/units/test_rack_request_proxy.rb
+++ b/test/units/test_rack_request_proxy.rb
@@ -1,7 +1,6 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/request_proxy/rack_request'
-require 'rack/request'
-require 'rack/mock'
 
 class RackRequestProxyTest < Minitest::Test
 

--- a/test/units/test_request_token.rb
+++ b/test/units/test_request_token.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class StubbedToken < OAuth::RequestToken
   define_method :build_authorize_url_promoted do |root_domain, params|

--- a/test/units/test_rest_client_request_proxy.rb
+++ b/test/units/test_rest_client_request_proxy.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 begin
   require 'oauth/request_proxy/rest_client_request'

--- a/test/units/test_rsa_sha1.rb
+++ b/test/units/test_rsa_sha1.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/consumer'
 require 'oauth/signature/rsa/sha1'
 

--- a/test/units/test_server.rb
+++ b/test/units/test_server.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/server'
 
 class ServerTest < Minitest::Test

--- a/test/units/test_signature.rb
+++ b/test/units/test_signature.rb
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 class TestOauth < Minitest::Test
 

--- a/test/units/test_signature_base.rb
+++ b/test/units/test_signature_base.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/signature/base'
 require 'net/http'
 

--- a/test/units/test_signature_hmac_sha1.rb
+++ b/test/units/test_signature_hmac_sha1.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/signature/hmac/sha1'
 
 class SignatureHMACSHA1Test < Minitest::Test

--- a/test/units/test_signature_plain_text.rb
+++ b/test/units/test_signature_plain_text.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/signature/plaintext'
 
 class TestSignaturePlaintext < Minitest::Test

--- a/test/units/test_token.rb
+++ b/test/units/test_token.rb
@@ -1,4 +1,5 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
+
 require 'oauth/token'
 
 class TestToken < Minitest::Test

--- a/test/units/test_typhoeus_request_proxy.rb
+++ b/test/units/test_typhoeus_request_proxy.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper_units', __FILE__)
+require File.expand_path('../../test_helper', __FILE__)
 
 begin
 


### PR DESCRIPTION

 - Adding support to Ruby 2.4 and head
 - Upgrading to CodeClimate 1.0
 - Nokogiri 1.7 does not accept Ruby 2.0
 - TravisCI no longer needs libcurl-dev
 - minor cleanup on tests