### PR TITLE
Add `require 'typhoeus'` to README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -51,6 +51,7 @@ When user returns create an access_token
 
 Now that you have an access token, you can use Typhoeus to interact with the OAuth provider if you choose.
 
+  require 'typhoeus'
   require 'oauth/request_proxy/typhoeus_request'
   oauth_params = {:consumer => oauth_consumer, :token => access_token}
   hydra = Typhoeus::Hydra.new


### PR DESCRIPTION
I felt this step was missing when trying to make my first requests using this gem, so I added it - I think it will help out people new to this project.