### PR TITLE
Fix typo in CLI docs 'none' -> 'nonce'

### DIFF
--- a/lib/oauth/cli/base_command.rb
+++ b/lib/oauth/cli/base_command.rb
@@ -126,7 +126,7 @@ class OAuth::CLI
         options[:method] = v
       end
 
-      opts.on("--nonce NONCE", "Specifies the none to use.") do |v|
+      opts.on("--nonce NONCE", "Specifies the nonce to use.") do |v|
         options[:oauth_nonce] = v
       end
 

--- a/test/units/test_cli.rb
+++ b/test/units/test_cli.rb
@@ -280,7 +280,7 @@ Usage: oauth <command> [ARGS]
 
   options for signing and querying
         --method METHOD              Specifies the method (e.g. GET) to use when signing.
-        --nonce NONCE                Specifies the none to use.
+        --nonce NONCE                Specifies the nonce to use.
         --parameters PARAMS          Specifies the parameters to use when signing.
         --signature-method METHOD    Specifies the signature method to use; defaults to HMAC-SHA1.
         --token TOKEN                Specifies the token to use.


### PR DESCRIPTION
Just what it says on the tin ^