### PR TITLE
allow a redirect with different host, but same path

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -230,7 +230,14 @@ module OAuth
       when (300..399)
         # this is a redirect
         uri = URI.parse(response['location'])
-        response.error! if uri.path == path # careful of those infinite redirects
+        our_uri = URI.parse(site)
+
+        if uri.path == path && our_uri.host != uri.host
+            options[:site] = "#{uri.scheme}://#{uri.host}"
+            @http = create_http
+        end
+
+        response.error! if uri.path == path && our_uri.host == uri.host # careful of those infinite redirects
         self.token_request(http_method, uri.path, token, request_options, arguments)
       when (400..499)
         raise OAuth::Unauthorized, response

--- a/test/units/test_consumer.rb
+++ b/test/units/test_consumer.rb
@@ -202,6 +202,19 @@ class ConsumerTest < Minitest::Test
     assert_equal 'secret', hash[:oauth_token_secret]
   end
 
+  def test_follow_redirect_different_host_same_path
+    request_uri = URI.parse("https://example.com/request_token")
+    redirect_uri = URI.parse("https://foobar.com/request_token")
+
+    stub_request(:get, "http://example.com/request_token").to_return(:status => 301, :headers => {'Location' => redirect_uri.to_s})
+    stub_request(:get, "https://foobar.com/request_token").to_return(:body => "oauth_token=token&oauth_token_secret=secret")
+
+    hash = @consumer.token_request(:get, request_uri.path) {{ :oauth_token => 'token', :oauth_token_secret => 'secret' }}
+
+    assert_equal 'token', hash[:oauth_token]
+    assert_equal 'secret', hash[:oauth_token_secret]
+  end
+
   def test_that_can_provide_a_block_to_interpret_a_request_token_response
     @consumer.expects(:request).returns(create_stub_http_response)
 


### PR DESCRIPTION
When the response returns a redirect with a location that has a different host, but the path is still the same an error was thrown.
In the case of a change of host however, we do want to continue with a new request. The site and http object have to be updated with the new host url and a new request can be made.