### PR TITLE
 Allow empty parameters.

### DIFF
--- a/lib/oauth/client/helper.rb
+++ b/lib/oauth/client/helper.rb
@@ -27,7 +27,7 @@ module OAuth::Client
     end
 
     def oauth_parameters
-      {
+      out = {
         'oauth_body_hash'        => options[:body_hash],
         'oauth_callback'         => options[:oauth_callback],
         'oauth_consumer_key'     => options[:consumer].key,
@@ -38,7 +38,11 @@ module OAuth::Client
         'oauth_verifier'         => options[:oauth_verifier],
         'oauth_version'          => (options[:oauth_version] || '1.0'),
         'oauth_session_handle'   => options[:oauth_session_handle]
-      }.reject { |k,v| v.to_s == "" }
+      }
+      if !options[:allow_empty_params]
+        out.reject! { |k,v| v.to_s == '' }
+      end
+      out
     end
 
     def signature(extra_options = {})

--- a/lib/oauth/client/helper.rb
+++ b/lib/oauth/client/helper.rb
@@ -39,9 +39,11 @@ module OAuth::Client
         'oauth_version'          => (options[:oauth_version] || '1.0'),
         'oauth_session_handle'   => options[:oauth_session_handle]
       }
-      if !options[:allow_empty_params]
-        out.reject! { |k,v| v.to_s == '' }
+      allowed_empty_params = options[:allow_empty_params]
+      if allowed_empty_params != true && !allowed_empty_params.kind_of?(Array)
+        allowed_empty_params = allowed_empty_params == false ? [] : [allowed_empty_params]
       end
+      out.select! { |k,v| v.to_s != '' || allowed_empty_params == true || allowed_empty_params.include?(k) }
       out
     end
 

--- a/lib/oauth/version.rb
+++ b/lib/oauth/version.rb
@@ -1,3 +1,3 @@
 module OAuth
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 end

--- a/test/units/test_client_helper.rb
+++ b/test/units/test_client_helper.rb
@@ -1,0 +1,147 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+require 'oauth/client'
+
+class ClientHelperTest < Minitest::Test
+
+  def setup
+    @consumer=OAuth::Consumer.new(
+        'consumer_key_86cad9', '5888bf0345e5d237',
+        {
+        :site=>"http://blabla.bla",
+        :proxy=>"http://user:password@proxy.bla:8080",
+        :request_token_path=>"/oauth/example/request_token.php",
+        :access_token_path=>"/oauth/example/access_token.php",
+        :authorize_path=>"/oauth/example/authorize.php",
+        :scheme=>:header,
+        :http_method=>:get
+        })
+  end
+
+  def test_oauth_parameters_allow_empty_params_default
+    helper = OAuth::Client::Helper.new(nil, {
+      :consumer => @consumer
+    })
+    helper.stub :timestamp, '0' do
+      helper.stub :nonce, 'nonce' do
+        expected = {
+          "oauth_consumer_key"=>"consumer_key_86cad9",
+          "oauth_signature_method"=>"HMAC-SHA1",
+          "oauth_timestamp"=>"0",
+          "oauth_nonce"=>"nonce",
+          "oauth_version"=>"1.0"
+        }
+        assert_equal expected, helper.oauth_parameters
+      end
+    end
+  end
+
+  def test_oauth_parameters_allow_empty_params_true
+    input = true
+    helper = OAuth::Client::Helper.new(nil, {
+      :consumer => @consumer,
+      :allow_empty_params => input
+    })
+    helper.stub :timestamp, '0' do
+      helper.stub :nonce, 'nonce' do
+        expected = {
+          "oauth_body_hash"=>nil,
+          "oauth_callback"=>nil,
+          "oauth_consumer_key"=>"consumer_key_86cad9",
+          "oauth_token"=>"",
+          "oauth_signature_method"=>"HMAC-SHA1",
+          "oauth_timestamp"=>"0",
+          "oauth_nonce"=>"nonce",
+          "oauth_verifier"=>nil,
+          "oauth_version"=>"1.0",
+          "oauth_session_handle"=>nil
+        }
+        assert_equal expected, helper.oauth_parameters
+      end
+    end
+  end
+
+  def test_oauth_parameters_allow_empty_params_false
+    input = false
+    helper = OAuth::Client::Helper.new(nil, {
+      :consumer => @consumer,
+      :allow_empty_params => input
+    })
+    helper.stub :timestamp, '0' do
+      helper.stub :nonce, 'nonce' do
+        expected = {
+          "oauth_consumer_key"=>"consumer_key_86cad9",
+          "oauth_signature_method"=>"HMAC-SHA1",
+          "oauth_timestamp"=>"0",
+          "oauth_nonce"=>"nonce",
+          "oauth_version"=>"1.0"
+        }
+        assert_equal expected, helper.oauth_parameters
+      end
+    end
+  end
+
+  def test_oauth_parameters_allow_empty_params_only_oauth_token_as_string
+    input = 'oauth_token'
+    helper = OAuth::Client::Helper.new(nil, {
+      :consumer => @consumer,
+      :allow_empty_params => input
+    })
+    helper.stub :timestamp, '0' do
+      helper.stub :nonce, 'nonce' do
+        expected = {
+          "oauth_consumer_key"=>"consumer_key_86cad9",
+          "oauth_token"=>"",
+          "oauth_signature_method"=>"HMAC-SHA1",
+          "oauth_timestamp"=>"0",
+          "oauth_nonce"=>"nonce",
+          "oauth_version"=>"1.0",
+        }
+        assert_equal expected, helper.oauth_parameters
+      end
+    end
+  end
+
+  def test_oauth_parameters_allow_empty_params_only_oauth_token_as_array
+    input = ['oauth_token']
+    helper = OAuth::Client::Helper.new(nil, {
+      :consumer => @consumer,
+      :allow_empty_params => input
+    })
+    helper.stub :timestamp, '0' do
+      helper.stub :nonce, 'nonce' do
+        expected = {
+          "oauth_consumer_key"=>"consumer_key_86cad9",
+          "oauth_token"=>"",
+          "oauth_signature_method"=>"HMAC-SHA1",
+          "oauth_timestamp"=>"0",
+          "oauth_nonce"=>"nonce",
+          "oauth_version"=>"1.0",
+        }
+        assert_equal expected, helper.oauth_parameters
+      end
+    end
+  end
+
+  def test_oauth_parameters_allow_empty_params_oauth_token_and_oauth_session_handle
+    input = ['oauth_token', 'oauth_session_handle']
+    helper = OAuth::Client::Helper.new(nil, {
+      :consumer => @consumer,
+      :allow_empty_params => input
+    })
+    helper.stub :timestamp, '0' do
+      helper.stub :nonce, 'nonce' do
+        expected = {
+          "oauth_consumer_key"=>"consumer_key_86cad9",
+          "oauth_token"=>"",
+          "oauth_signature_method"=>"HMAC-SHA1",
+          "oauth_timestamp"=>"0",
+          "oauth_nonce"=>"nonce",
+          "oauth_version"=>"1.0",
+          "oauth_session_handle"=>nil
+        }
+        assert_equal expected, helper.oauth_parameters
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some implementations sign the payload with empty parameters.
As a result, since the library filters out any empty parameters, it couldn't be used to generate the expected signature.

This attempts to imitate the following statement from postman:
https://www.getpostman.com/docs/v6/postman/sending_api_requests/authorization
> Note: Some implementations of OAuth 1.0 require empty parameters to be added to the signature. 
> You can select “Add empty parameters to signature” to add empty parameters.
