### PR TITLE
Implement authenticate_url

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -23,6 +23,7 @@ module OAuth
 
       # default paths on site. These are the same as the defaults set up by the generators
       :request_token_path => '/oauth/request_token',
+      :authenticate_path  => '/oauth/authenticate',
       :authorize_path     => '/oauth/authorize',
       :access_token_path  => '/oauth/access_token',
 
@@ -266,6 +267,10 @@ module OAuth
       @options[:request_token_path]
     end
 
+    def authenticate_path
+      @options[:authenticate_path]
+    end
+
     def authorize_path
       @options[:authorize_path]
     end
@@ -281,6 +286,14 @@ module OAuth
 
     def request_token_url?
       @options.has_key?(:request_token_url)
+    end
+
+    def authenticate_url
+      @options[:authenticate_url] || site + authenticate_path
+    end
+
+    def authenticate_url?
+      @options.has_key?(:authenticate_url)
     end
 
     def authorize_url

--- a/lib/oauth/tokens/request_token.rb
+++ b/lib/oauth/tokens/request_token.rb
@@ -8,14 +8,14 @@ module OAuth
       return nil if self.token.nil?
 
       params = (params || {}).merge(:oauth_token => self.token)
-      build_authorize_url(consumer.authorize_url, params)
+      build_url(consumer.authorize_url, params)
     end
 
     def authenticate_url(params = nil)
       return nil if self.token.nil?
 
       params = (params || {}).merge(:oauth_token => self.token)
-      build_authenticate_url(consumer.authenticate_url, params)
+      build_url(consumer.authenticate_url, params)
     end
 
     def callback_confirmed?
@@ -30,19 +30,8 @@ module OAuth
 
   protected
 
-    # construct an authorization url
-    def build_authorize_url(base_url, params)
-      uri = URI.parse(base_url.to_s)
-      queries = {}
-      queries = Hash[URI.decode_www_form(uri.query)] if uri.query
-      # TODO doesn't handle array values correctly
-      queries.merge!(params) if params
-      uri.query = URI.encode_www_form(queries) if !queries.empty?
-      uri.to_s
-    end
-
-    # construct an authenticate url
-    def build_authenticate_url(base_url, params)
+    # construct an authorization or authentication url
+    def build_url(base_url, params)
       uri = URI.parse(base_url.to_s)
       queries = {}
       queries = Hash[URI.decode_www_form(uri.query)] if uri.query

--- a/lib/oauth/tokens/request_token.rb
+++ b/lib/oauth/tokens/request_token.rb
@@ -11,6 +11,13 @@ module OAuth
       build_authorize_url(consumer.authorize_url, params)
     end
 
+    def authenticate_url(params = nil)
+      return nil if self.token.nil?
+
+      params = (params || {}).merge(:oauth_token => self.token)
+      build_authenticate_url(consumer.authenticate_url, params)
+    end
+
     def callback_confirmed?
       params[:oauth_callback_confirmed] == "true"
     end
@@ -25,6 +32,17 @@ module OAuth
 
     # construct an authorization url
     def build_authorize_url(base_url, params)
+      uri = URI.parse(base_url.to_s)
+      queries = {}
+      queries = Hash[URI.decode_www_form(uri.query)] if uri.query
+      # TODO doesn't handle array values correctly
+      queries.merge!(params) if params
+      uri.query = URI.encode_www_form(queries) if !queries.empty?
+      uri.to_s
+    end
+
+    # construct an authenticate url
+    def build_authenticate_url(base_url, params)
       uri = URI.parse(base_url.to_s)
       queries = {}
       queries = Hash[URI.decode_www_form(uri.query)] if uri.query

--- a/lib/oauth/version.rb
+++ b/lib/oauth/version.rb
@@ -1,3 +1,3 @@
 module OAuth
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 end

--- a/test/units/test_request_token.rb
+++ b/test/units/test_request_token.rb
@@ -1,8 +1,8 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class StubbedToken < OAuth::RequestToken
-  define_method :build_authorize_url_promoted do |root_domain, params|
-    build_authorize_url root_domain, params
+  define_method :build_url_promoted do |root_domain, params|
+    build_url root_domain, params
   end
 end
 
@@ -40,14 +40,38 @@ class TestRequestToken < Minitest::Test
     assert_nil @request_token.authorize_url
   end
 
+  def test_request_token_builds_authenticate_url_connectly_with_additional_params
+    authenticate_url = @request_token.authenticate_url({:oauth_callback => "github.com"})
+    assert authenticate_url
+    assert_match(/oauth_token/, authenticate_url)
+    assert_match(/oauth_callback/, authenticate_url)
+  end
+
+  def test_request_token_builds_authenticate_url_connectly_with_no_or_nil_params
+    # we should only have 1 key in the url returned if we didn't pass anything.
+    # this is the only required param to authenticate the client.
+    authenticate_url = @request_token.authenticate_url(nil)
+    assert authenticate_url
+    assert_match(/\?oauth_token=/, authenticate_url)
+
+    authenticate_url2 = @request_token.authenticate_url
+    assert authenticate_url2
+    assert_match(/\?oauth_token=/, authenticate_url2)
+  end
+
+  def test_request_token_returns_nil_authenticate_url_when_token_is_nil
+    @request_token.token = nil
+    assert_nil @request_token.authenticate_url
+  end
+
   #TODO: mock out the Consumer to test the Consumer/AccessToken interaction.
   def test_get_access_token
   end
 
-  def test_build_authorize_url
+  def test_build_url
    @stubbed_token = StubbedToken.new(nil, nil, nil)
-    assert_respond_to @stubbed_token, :build_authorize_url_promoted
-    url = @stubbed_token.build_authorize_url_promoted(
+    assert_respond_to @stubbed_token, :build_url_promoted
+    url = @stubbed_token.build_url_promoted(
       "http://github.com/oauth/authorize",
       {:foo => "bar bar"})
     assert url


### PR DESCRIPTION
Solve issue https://github.com/oauth-xx/oauth-ruby/issues/161

## SUMMARY
1. Adds authenticate_url methods.
2. Bumps version number

## VERIFICATION
I did some testing and it works.

Very simple code to verify:
```ruby
#!/usr/bin/ruby
require 'oauth'
require 'sinatra'

CONSUMER_KEY = ENV['CONSUMER_KEY']
CONSUMER_SECRET = ENV['CONSUMER_SECRET']

raise 'Missing Consumer' if CONSUMER_KEY.nil? || CONSUMER_SECRET.nil?

set :port, 8000
set :bind, '0.0.0.0'

consumer = OAuth::Consumer.new(CONSUMER_KEY, CONSUMER_SECRET, site: 'https://api.twitter.com')

get '/' do
  "Hello World!"
end

get '/register' do
  request_token = consumer.get_request_token oauth_callback: 'https://twitter-test.agora-security.com/auth/twitter/callback'
  redirect request_token.authorize_url
end

get '/login' do
  request_token = consumer.get_request_token oauth_callback: 'https://twitter-test.agora-security.com/auth/twitter/callback'
  redirect request_token.authenticate_url
end

get '/auth/twitter/callback' do
  # Using https://developer.twitter.com/en/docs/twitter-for-websites/log-in-with-twitter/guides/implementing-sign-in-with-twitter
  # Step 1 - First request
  request_token = consumer.get_request_token oauth_callback: 'https://twitter-test.agora-security.com/auth/twitter/callback'
  # Step 2 - Receive callback
  request_token.token = params["oauth_token"]
  # Step 3 - Converting the request token to an access token
  access_token = request_token.get_access_token(:oauth_verifier => params["oauth_verifier"])
  username = access_token.params.dig 'screen_name'
  timestamp = Time.now.to_i
  params = access_token.params
  status 200
  body "Welcome #{username}. You are logged in :)"
end

```

Note: The code to verify, requires that you have a Twitter App, a domain and your app configured with the proper call back URL.