### PR TITLE
increase default timeout to 60 seconds

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -371,7 +371,7 @@ module OAuth
         http_object.verify_depth = 5
       end
 
-      http_object.read_timeout = http_object.open_timeout = @options[:timeout] || 30
+      http_object.read_timeout = http_object.open_timeout = @options[:timeout] || 60
       http_object.open_timeout = @options[:open_timeout] if @options[:open_timeout]
       http_object.ssl_version = @options[:ssl_version] if @options[:ssl_version]
       http_object.set_debug_output(debug_output) if debug_output


### PR DESCRIPTION
From the Net::HTTP Class, the default values are:

- `read_timeout`: 60 (seconds) [document](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method)
- `open_timeout`: 60 (seconds) [document](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method)

Or, is there any specific reason this library wants to set 30 seconds over that default values?