### PR TITLE
Avoid using ssl no verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: ruby
 
 rvm:
 - "ruby-head"
+- "2.7"
 - "2.4.0"
 - "2.3"
 - "2.2"
-
+matrix:
+  allow_failures:
+    - rvm: "ruby-head"
 addons:
   code_climate:
     repo_token: 8f697ca756250f0c2c54170ae27e8a9c459d18a0236903b11291c88291b3aac9

--- a/oauth.gemspec
+++ b/oauth.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("iconv")
   spec.add_development_dependency("rack", "~> 2.0")
   spec.add_development_dependency("rack-test")
-  spec.add_development_dependency("mocha", ">= 0.9.12")
+  spec.add_development_dependency("mocha", ">= 0.9.12", "<=1.1.0")
   spec.add_development_dependency("typhoeus", ">= 0.1.13")
   spec.add_development_dependency("em-http-request", "0.2.11")
   spec.add_development_dependency("curb")

--- a/test/units/test_consumer.rb
+++ b/test/units/test_consumer.rb
@@ -165,6 +165,54 @@ class ConsumerTest < Minitest::Test
    @consumer.get_request_token
   end
 
+  def test_noverify_true
+    @consumer = OAuth::Consumer.new(
+     "key",
+     "secret",
+     {
+         :site              => "https://api.mysite.co.nz/v1",
+         :request_token_url => "https://authentication.mysite.co.nz/Oauth/RequestToken",
+         :no_verify         => true
+     })
+
+    stub_request(:post, "https://authentication.mysite.co.nz/Oauth/RequestToken").to_return(:body => "success", :status => 200)
+
+    Net::HTTP.any_instance.expects(:'verify_mode=').with(OpenSSL::SSL::VERIFY_NONE)
+
+    @consumer.get_request_token
+  end
+
+  def test_noverify_false
+    @consumer = OAuth::Consumer.new(
+     "key",
+     "secret",
+     {
+         :site              => "https://api.mysite.co.nz/v1",
+         :request_token_url => "https://authentication.mysite.co.nz/Oauth/RequestToken",
+         :no_verify         => false
+     })
+
+    stub_request(:post, "https://authentication.mysite.co.nz/Oauth/RequestToken").to_return(:body => "success", :status => 200)
+
+    Net::HTTP.any_instance.expects(:'verify_mode=').with(OpenSSL::SSL::VERIFY_PEER)
+    @consumer.get_request_token
+  end
+
+  def test_noverify_empty
+    @consumer = OAuth::Consumer.new(
+     "key",
+     "secret",
+     {
+         :site              => "https://api.mysite.co.nz/v1",
+         :request_token_url => "https://authentication.mysite.co.nz/Oauth/RequestToken"
+     })
+
+    stub_request(:post, "https://authentication.mysite.co.nz/Oauth/RequestToken").to_return(:body => "success", :status => 200)
+
+    Net::HTTP.any_instance.expects(:'verify_mode=').with(OpenSSL::SSL::VERIFY_PEER)
+    @consumer.get_request_token
+  end
+
   def test_token_request_identifies_itself_as_a_token_request
     request_options = {}
     @consumer.stubs(:request).returns(create_stub_http_response)


### PR DESCRIPTION
Should _only_ use no_verify when no_verify: false is passed as an option to  OAuth::Consumer.new