### PR TITLE
Add metadata to gemspec file

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,7 @@
 === CURRENT
 
+* Add metadata to Gemspec file
+
 === 0.5.5 2020-01-19
 
 * Allow redirect to different host but same path

--- a/oauth.gemspec
+++ b/oauth.gemspec
@@ -15,6 +15,14 @@ Gem::Specification.new do |spec|
   spec.summary     = "OAuth Core Ruby implementation"
 
   spec.executables = ["oauth"]
+  spec.homepage = "https://github.com/oauth-xx/oauth-ruby"
+  spec.metadata = {
+    'bug_tracker_uri' => "#{spec.homepage}/issues",
+    'changelog_uri' => "#{spec.homepage}/blob/master/HISTORY",
+    'documentation_uri' => "https://rdoc.info/github/oauth-xx/oauth-ruby/master/frames",
+    'homepage_uri' => spec.homepage,
+    'source_code_uri' => spec.homepage
+  }
   spec.files       = Dir.glob("lib/**/*.rb")
   #spec.test_files  = Dir.glob("test/**/*.rb") + Dir.glob('test/keys/*')
   spec.extra_rdoc_files = [ "LICENSE", "README.rdoc", "TODO" ]


### PR DESCRIPTION
I've received an update of `oauth` gem in some of my project viad dependabot, and it's shown no changelog, no official repo, no commit history or any useful info

I got to [rubygems](https://rubygems.org/gems/oauth/versions/0.5.1) page and see there is no metadata in right column:
![image](https://user-images.githubusercontent.com/668524/105314773-61142480-5bcf-11eb-9aa1-abeee5691c42.png)

Adding metadata in gemfile will result something like this:
![Screenshot from 2021-01-21 10-00-16](https://user-images.githubusercontent.com/668524/105314875-8a34b500-5bcf-11eb-8252-05facd39a7ab.png)
