### PR TITLE
Add `OAuth::Signature::HMAC::SHA256` and associated tests

### DIFF
--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -7,5 +7,6 @@ require 'oauth/oauth'
 
 require 'oauth/client/helper'
 require 'oauth/signature/hmac/sha1'
+require 'oauth/signature/hmac/sha256'
 require 'oauth/signature/rsa/sha1'
 require 'oauth/request_proxy/mock_request'

--- a/lib/oauth/signature/hmac/sha256.rb
+++ b/lib/oauth/signature/hmac/sha256.rb
@@ -1,0 +1,17 @@
+require 'oauth/signature/base'
+
+module OAuth::Signature::HMAC
+  class SHA256 < OAuth::Signature::Base
+    implements 'hmac-sha256'
+
+    def body_hash
+      Base64.encode64(OpenSSL::Digest::SHA256.digest(request.body || '')).chomp.gsub(/\n/,'')
+    end
+
+    private
+
+    def digest
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), secret, signature_base_string)
+    end
+  end
+end

--- a/test/units/test_hmac_sha256.rb
+++ b/test/units/test_hmac_sha256.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class TestSignatureHmacSha256 < Minitest::Test
+  def test_that_hmac_sha256_implements_hmac_sha256
+    assert OAuth::Signature.available_methods.include?('hmac-sha256')
+  end
+
+  def test_that_get_request_from_oauth_test_cases_produces_matching_signature
+    request = Net::HTTP::Get.new('/photos?file=vacation.jpg&size=original&oauth_version=1.0&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_token=nnch734d00sl2jdk&oauth_timestamp=1191242096&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA256')
+
+    consumer = OAuth::Consumer.new('dpf43f3p2l4k3l03', 'kd94hf93k423kf44')
+    token = OAuth::Token.new('nnch734d00sl2jdk', 'pfkkdhi9sl3r4s00')
+
+    signature = OAuth::Signature.sign(request, { :consumer => consumer,
+                                                 :token => token,
+                                                 :uri => 'http://photos.example.net/photos',
+                                                 :signature_method => 'HMAC-SHA256' } )
+
+    assert_equal 'WVPzl1j6ZsnkIjWr7e3OZ3jkenL57KwaLFhYsroX1hg=', signature
+  end
+end

--- a/test/units/test_signature_hmac_sha256.rb
+++ b/test/units/test_signature_hmac_sha256.rb
@@ -1,0 +1,41 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+require 'oauth/signature/hmac/sha256'
+
+class SignatureHMACSHA256Test < Minitest::Test
+  def test_that_verify_returns_true_when_the_request_signature_is_right
+    request = OAuth::RequestProxy::MockRequest.new(
+      'method' => 'POST',
+      'uri' => 'https://photos.example.net/initialize',
+      'parameters' => {
+        'oauth_consumer_key' => 'dpf43f3p2l4k3l03',
+        'oauth_signature_method' => 'HMAC-SHA256',
+        'oauth_timestamp' => '137131200',
+        'oauth_nonce' => 'wIjqoS',
+        'oauth_callback' => 'http://printer.example.com/ready',
+        'oauth_version' => '1.0',
+        'oauth_signature' => 'tkpCGNHi3laWBHQ9+Ka5IOeixEuhxg12LTMlLJxQxKc='
+      }
+    )
+    assert OAuth::Signature::HMAC::SHA256.new(request, :consumer_secret => 'kd94hf93k423kf44').verify
+  end
+
+  def test_that_verify_returns_false_when_the_request_signature_is_wrong
+    # Test a bug in the OAuth::Signature::Base#== method: when the Base64.decode64 method is
+    # used on the "self" and "other" signature (as in version 0.4.7), the result may be incorrectly "true".
+    request = OAuth::RequestProxy::MockRequest.new(
+      'method' => 'POST',
+      'uri' => 'https://photos.example.net/initialize',
+      'parameters' => {
+        'oauth_consumer_key' => 'dpf43f3p2l4k3l03',
+        'oauth_signature_method' => 'HMAC-SHA256',
+        'oauth_timestamp' => '137131200',
+        'oauth_nonce' => 'wIjqoS',
+        'oauth_callback' => 'http://printer.example.com/ready',
+        'oauth_version' => '1.0',
+        'oauth_signature' => 'tkpCGNHi3laWBHQ9+Ka5IOeixEuhxg12LTMlLJxQxKZ='
+      }
+    )
+    assert !OAuth::Signature::HMAC::SHA256.new(request, :consumer_secret => 'kd94hf93k423kf44').verify
+  end
+end


### PR DESCRIPTION
I've had a requirement to start using HMAC-SHA256 on a project and thought it would be useful to push upstream. I've based the implementation directly on that of HMAC-SHA1.

Please let me know if this is wanted, or if I missed a test file (I took a look though and duplicated the ones I thought were necessary).