### PR TITLE
Action Controller support for PUT requests

### DIFF
--- a/lib/oauth/request_proxy/action_controller_request.rb
+++ b/lib/oauth/request_proxy/action_controller_request.rb
@@ -60,7 +60,7 @@ module OAuth::RequestProxy
         params << header_params.to_query
         params << request.query_string unless query_string_blank?
 
-        if request.post? && request.content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
+        if raw_post_signature?
           params << request.raw_post
         end
       end
@@ -70,6 +70,10 @@ module OAuth::RequestProxy
         reject { |s| s.match(/\A\s*\z/) }.
         map { |p| p.split('=').map{|esc| CGI.unescape(esc)} }.
         reject { |kv| kv[0] == 'oauth_signature'}
+    end
+
+    def raw_post_signature?
+      (request.post? || request.put?) && request.content_type.to_s.downcase.start_with?("application/x-www-form-urlencoded")
     end
 
   protected

--- a/test/units/test_action_controller_request_proxy.rb
+++ b/test/units/test_action_controller_request_proxy.rb
@@ -77,7 +77,7 @@ class ActionControllerRequestProxyTest < Minitest::Test
   def test_that_proxy_simple_put_request_works_with_post_params
     request_proxy = request_proxy(:put, {}, {'key'=>'value'})
 
-    expected_parameters = []
+    expected_parameters = [["key", "value"]]
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'PUT', request_proxy.method
   end
@@ -109,7 +109,7 @@ class ActionControllerRequestProxyTest < Minitest::Test
   def test_that_proxy_simple_put_request_works_with_mixed_params
     request_proxy = request_proxy(:put, {'key'=>'value'}, {'key2'=>'value2'})
 
-    expected_parameters = [["key", "value"]]
+    expected_parameters = [["key", "value"],["key2", "value2"]]
     assert_equal expected_parameters, request_proxy.parameters_for_signature
     assert_equal 'PUT', request_proxy.method
   end


### PR DESCRIPTION
Most of the other request proxies support PUT
requests and we need this gem to also support it
for Action Controller. This addresses issue #180

It includes the modified Action Controller proxy
and fixes the tests.