### PR TITLE
Option to disable oauth_body_hash computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Made a new option `body_hash_enabled` which defaults to true to maintain backward compatibility with prior releases. Setting to `false` disables generation of a `oauth_body_hash` component as part of the signature computation.
 
 ### Fixed
 

--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -64,6 +64,11 @@ module OAuth
       # some_value - uses some_value
       debug_output: nil,
 
+      # Defaults to producing a body_hash as part of the signature but
+      # can be disabled since it's not officially part of the OAuth 1.0
+      # spec. Possible values are true and false
+      body_hash_enabled: true,
+
       oauth_version: "1.0"
     }
 
@@ -78,7 +83,8 @@ module OAuth
     #     :http_method        => :post,
     #     :request_token_path => "/oauth/example/request_token.php",
     #     :access_token_path  => "/oauth/example/access_token.php",
-    #     :authorize_path     => "/oauth/example/authorize.php"
+    #     :authorize_path     => "/oauth/example/authorize.php",
+    #     :body_hash_enabled  => false
     #    })
     #
     # Start the process by requesting a token

--- a/test/units/test_net_http_client.rb
+++ b/test/units/test_net_http_client.rb
@@ -310,6 +310,16 @@ class NetHTTPClientTest < Minitest::Test
                  signature_base_string
   end
 
+  def test_that_post_bodies_not_signed_if_body_hash_disabled
+    request = Net::HTTP::Post.new(@request_uri.path)
+    request.body = "<?xml version=\"1.0\"?><foo><bar>baz</bar></foo>"
+    request["Content-Type"] = "application/xml"
+    signature_base_string = request.signature_base_string(@http, @consumer, nil,
+                                                          { nonce: @nonce, timestamp: @timestamp, body_hash_enabled: false })
+    assert_equal "POST&http%3A%2F%2Fexample.com%2Ftest&oauth_consumer_key%3Dconsumer_key_86cad9%26oauth_nonce%3D225579211881198842005988698334675835446%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1199645624%26oauth_version%3D1.0",
+                 signature_base_string
+  end
+
   def test_that_site_address_is_not_modified_in_place
     options = { site: "http://twitter.com", request_endpoint: "http://api.twitter.com" }
     request = Net::HTTP::Get.new("#{@request_uri.path}?#{request_parameters_to_s}")


### PR DESCRIPTION
Not all OAuth 1.0 implementations recognize or respect `oauth_body_hash` in the base signature for POST/PUT payloads that are not url-encoded. Provides simple mechanism to disable this feature for improved compatibility.