### PR TITLE
revert transform_keys change

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -103,7 +103,9 @@ module OAuth
       @secret = consumer_secret
 
       # ensure that keys are symbols
-      @options = @@default_options.merge(options.transform_keys(&:to_sym))
+      @options = @@default_options.merge(options.each_with_object({}) do |(key, value), opts| 
+        opts[key.to_sym] = value 
+      end)
     end
 
     # The default http method


### PR DESCRIPTION
Closes https://github.com/oauth-xx/oauth-ruby/issues/271 by reverting the `transform_keys` change

omniauth ultimately defines `options` as a `Hashie::Mash` not a `Hash`:
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L547
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/key_store.rb#L5

While `Hashie::Mash` does implement `transform_keys`, it does not behave the same way as the `Hash` implementation does:

```rb
Hashie::Mash.new(one: "1", two: "2").transform_keys(&:to_sym)
{"one"=>"1", "two"=>"2"}

Hashie::Mash.new(one: "1", two: "2").to_hash.transform_keys(&:to_sym)
=> {:one=>"1", :two=>"2"}
```

---

🤔 An alternative could be to rewrite the existing line to:

```rb
@options = @@default_options.merge(options.to_hash.transform_keys(&:to_sym)) 
```

<details>
<summary>Never mind this idea 😬 </summary>
Ah! Another option is to add `.with_indifferent_access` when `@@default_options` is created:
https://github.com/oauth-xx/oauth-ruby/blob/62d3f3e52daa565a04e508df915456a21a7faf37/lib/oauth/consumer.rb#L33-L73

```rb
irb(main):001:0> hh = {one: '1', two: '2'}
=> {:one=>"1", :two=>"2"}
irb(main):002:0> hm = Hashie::Mash.new(one: "one", two: "two")
=> {"one"=>"1", "two"=>"2"}
irb(main):003:0> mm = hh.merge(hm)
=> {:one=>"1", :two=>"2", "one"=>"one", "two"=>"two"}
irb(main):004:0> hh = {one: '1', two: '2'}.with_indifferent_access
=> {"one"=>"1", "two"=>"2"}
irb(main):005:0> mm = hh.merge(hm)
=> {"one"=>"one", "two"=>"two"}
irb(main):006:0> mm[:one]
=> "one"
```
</details>

I don't expect the removal of Hashie from omniauth to be possible, based on how purposeful they were in switching to it:
https://github.com/omniauth/omniauth/wiki/OmniAuth-1.0#changes-to-the-auth-hash