### PR TITLE
add .with_indifferent_access to default_options

### DIFF
--- a/lib/oauth/consumer.rb
+++ b/lib/oauth/consumer.rb
@@ -70,7 +70,7 @@ module OAuth
       body_hash_enabled: true,
 
       oauth_version: "1.0"
-    }
+    }.with_indifferent_access
 
     attr_accessor :options, :key, :secret
     attr_writer   :site, :http


### PR DESCRIPTION
A simpler solution to https://github.com/oauth-xx/oauth-ruby/issues/271 ... replaces https://github.com/oauth-xx/oauth-ruby/pull/272

omniauth ultimately defines `options` as a `Hashie::Mash` not a `Hash`:
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L547
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/key_store.rb#L5

While `Hashie::Mash` does implement `transform_keys`, it does not behave the same way as the `Hash` implementation does:

```rb
Hashie::Mash.new(one: "1", two: "2").transform_keys(&:to_sym)
{"one"=>"1", "two"=>"2"}

Hashie::Mash.new(one: "1", two: "2").to_hash.transform_keys(&:to_sym)
=> {:one=>"1", :two=>"2"}
```

Setting the `default_options` to indifferent access lets the two hashes merge properly:

```rb
irb(main):001:0> hh = {one: '1', two: '2'}
=> {:one=>"1", :two=>"2"}
irb(main):002:0> hm = Hashie::Mash.new(one: "one", two: "two")
=> {"one"=>"1", "two"=>"2"}
irb(main):003:0> mm = hh.merge(hm)
=> {:one=>"1", :two=>"2", "one"=>"one", "two"=>"two"}
irb(main):004:0> hh = {one: '1', two: '2'}.with_indifferent_access
=> {"one"=>"1", "two"=>"2"}
irb(main):005:0> mm = hh.merge(hm)
=> {"one"=>"one", "two"=>"two"}
irb(main):006:0> mm[:one]
=> "one"
```